### PR TITLE
Add reorgs, optimize blocks-to-disk & net usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ coverage
 yarn.lock
 .vscode
 data
-bin/ip.pref
 lockfile.lock
+Concord-Core-win32-x64
+Concord-Core-win32-x64.zip

--- a/lib/blockchain/index.js
+++ b/lib/blockchain/index.js
@@ -21,7 +21,6 @@ class Blockchain {
     this.blocksDb = new Db(appdataPath + dbName + '/' + BLOCKCHAIN_FILE, new Blocks())
     this.transactionsDb = new Db(appdataPath + dbName + '/' + TRANSACTIONS_FILE, new Transactions())
 
-    // INFO: In this implementation the database is a file and every time data is saved it rewrites the file, probably it should be a more robust database for performance reasons
     this.blocks = this.blocksDb.read(Blocks)
     this.transactions = this.transactionsDb.read(Transactions)
 
@@ -59,13 +58,13 @@ class Blockchain {
     return R.last(this.blocks)
   }
 
-  getDifficulty (index, blockchain = this.blocks, mixChains = false) {
+  getDifficulty (index, refBlockchain = this.blocks, mixChains = false) {
     // Calculates the difficulty based on the index since the difficulty value increases every X blocks.
-      let mixedChain = [...blockchain];
-      if(mixChains){
-          mixedChain.splice(0, this.blocks.length);
-          mixedChain = [].concat(this.blocks, mixedChain);
-      }
+    let mixedChain = [...refBlockchain];
+    if (mixChains) {
+        mixedChain.splice(0, this.blocks.length);
+        mixedChain = [].concat(this.blocks, mixedChain);
+    }
     return Config.pow.getDifficulty((mixChains && index >= this.blocks.length) ? mixedChain : this.blocks, index)
   }
 
@@ -81,7 +80,8 @@ class Blockchain {
     return R.find(R.compose(R.find(R.propEq('id', transactionId)), R.prop('transactions')), this.blocks)
   }
 
-  replaceChain (newBlockchain) {
+  replaceChain (newBlockchain, reorgToBlock = null) {
+    console.info("Replacing chain " + (reorgToBlock === null ? "without" : "with") + " a block reorganization")
     // It doesn't make sense to replace this blockchain by a smaller one
     if (newBlockchain.length <= this.blocks.length) {
       console.error('Blockchain shorter than the current blockchain')
@@ -89,7 +89,21 @@ class Blockchain {
     }
 
     // Verify if the new blockchain is correct
-    this.checkChain(newBlockchain)
+    this.checkChain(newBlockchain, (reorgToBlock === null ? false : true))
+
+    // REORG ONLY:
+    // Remove each of our forked blocks, saving each regular transaction
+    // along the way until we hit reorgToBlock.
+    let orphanTransactions = []
+    if (reorgToBlock !== null) {
+      for (let i=this.blocks.length - 1; this.blocks[i].index !== reorgToBlock.index; i--) {
+        // Save "regular" transactions
+        for (let a=0; a<this.blocks[i].transactions.length; a++) {
+          if (this.blocks[i].transactions[a].type === "regular") orphanTransactions.push(this.blocks[i].transactions[a])
+        }
+        this.blocks.pop()
+      }
+    }
 
     // Get the blocks that diverges from our blockchain
     console.info('Received blockchain is valid. Replacing current blockchain with received blockchain')
@@ -97,13 +111,19 @@ class Blockchain {
 
     // Add each new block to the blockchain
     R.forEach((block) => {
-      this.addBlock(block, false)
+      this.addBlock(block, false, (reorgToBlock === null ? false : true))
     }, newBlocks)
+
+    // REORG ONLY:
+    // Add and re-broadcast all orphaned regular transactions
+    R.forEach((transaction) => {
+      this.addTransaction(transaction)
+    }, orphanTransactions)
 
     this.emitter.emit('blockchainReplaced', newBlocks)
   }
 
-  checkChain (blockchainToValidate) {
+  checkChain (blockchainToValidate, reorg = false) {
     // Check if the genesis block is the same
     if (JSON.stringify(blockchainToValidate[0]) !== JSON.stringify(Block.genesis)) {
       console.error('Genesis blocks aren\'t the same')
@@ -113,7 +133,7 @@ class Blockchain {
     // Compare every block to the previous one (it skips the first one, because it was verified before)
     try {
       for (let i = 1; i < blockchainToValidate.length; i++) {
-        this.checkBlock(blockchainToValidate[i], blockchainToValidate[i - 1], blockchainToValidate)
+        this.checkBlock(blockchainToValidate[i], blockchainToValidate[i - 1], blockchainToValidate, reorg)
       }
     } catch (ex) {
       console.error('Invalid block sequence:' + ex.stack);
@@ -122,17 +142,43 @@ class Blockchain {
     return true
   }
 
-  addBlock (newBlock, emit = true) {
+  checkForForkTip (forkChain, refChain = this.blocks) {
+    // Scan both chains backwards, starting at the length of the shortest chain
+    let i, len = R.min(refChain.length, forkChain.length) - 1, forkTip = null
+    for (i=len; i>1; i--) {
+      // Search for the last matching block
+      if (refChain[i].hash === forkChain[i].hash) {
+        // Ensure an older block exists on both chains
+        if (refChain[i + 1] && forkChain[i + 1]) {
+          // Check if the hashes don't match
+          if (refChain[i + 1].hash !== forkChain[i + 1].hash) {
+            // Found a fork tip!
+            forkTip = refChain[i]
+          }
+        }
+      }
+    }
+    // If this returns null, a fork wasn't found
+    return forkTip
+  }
+
+  addBlock (newBlock, emit = true, reorg = false) {
     // It only adds the block if it's valid (we need to compare to the previous one)
-    if (this.checkBlock(newBlock, this.getLastBlock())) {
+    if (this.checkBlock(newBlock, this.getLastBlock(), this.blocks, reorg)) {
       this.blocks.push(newBlock)
-      this.blocksDb.write(this.blocks)
+
+      // Every 1000 blocks, write them to disk
+      if (this.blocks.length % 1000 === 0) {
+        console.info("Writing " + this.blocks.length + " blocks to disk...")
+        this.blocksDb.write(this.blocks)
+        console.info("Blocks written succesfully.")
+      }
 
       // After adding the block it removes the transactions of this block from the list of pending transactions
       this.removeBlockTransactionsFromTransactions(newBlock)
 
-      console.info(`Block added: ${newBlock.hash}`)
-      console.debug(`Block added: ${JSON.stringify(newBlock)}`)
+      console.info(`Block ${newBlock.index} added: ${newBlock.hash}`)
+      console.debug(`Block ${newBlock.index} added: ${JSON.stringify(newBlock)}`)
       if (emit) this.emitter.emit('blockAdded', newBlock)
 
       return newBlock
@@ -164,7 +210,7 @@ class Blockchain {
     this.transactionsDb.write(this.transactions)
   }
 
-  checkBlock (newBlock, previousBlock, referenceBlockchain = this.blocks) {
+  checkBlock (newBlock, previousBlock, referenceBlockchain = this.blocks, reorg = false) {
     const blockHash = newBlock.toHash()
 
     if (previousBlock.index + 1 !== newBlock.index) { // Check if the block is the last one
@@ -176,15 +222,22 @@ class Blockchain {
     } else if (blockHash !== newBlock.hash) { // Check if the hash is correct
       console.error(`Invalid hash: expected '${blockHash}' got '${newBlock.hash}'`)
       throw new BlockAssertionError(`Invalid hash: expected '${blockHash}' got '${newBlock.hash}'`)
-    } else if (newBlock.getDifficulty() >= this.getDifficulty(newBlock.index, referenceBlockchain, true)) { // If the difficulty level of the proof-of-work challenge is correct
-      console.error(`Invalid proof-of-work difficulty: expected '${newBlock.getDifficulty()}' to be smaller than '${this.getDifficulty(newBlock.index, referenceBlockchain, true)}'`)
-      throw new BlockAssertionError(`Invalid proof-of-work difficulty: expected '${newBlock.getDifficulty()}' be smaller than '${this.getDifficulty(newBlock.index, referenceBlockchain, true)}'`)
+    } else {
+      if (newBlock.getDifficulty() >= this.getDifficulty(newBlock.index, referenceBlockchain, true)) { // If the difficulty level of the proof-of-work challenge is correct
+        console.error(`Invalid proof-of-work difficulty: expected '${newBlock.getDifficulty()}' to be smaller than '${this.getDifficulty(newBlock.index, referenceBlockchain, true)}'`)
+        throw new BlockAssertionError(`Invalid proof-of-work difficulty: expected '${newBlock.getDifficulty()}' be smaller than '${this.getDifficulty(newBlock.index, referenceBlockchain, true)}'`)
+      }
     }
 
     // INFO: Here it would need to check if the block follows some expectation regarding the minimal number of transactions, value or data size to avoid empty blocks being mined.
 
-    // For each transaction in this block, check if it is valid
-    R.forEach(this.checkTransaction.bind(this), newBlock.transactions, referenceBlockchain)
+    // For each regular transaction in this block, check if it is valid
+    if (newBlock.transactions > 1) {
+      let i, len = newBlock.transactions.length
+      for (i=0; i<len; i++) {
+        this.checkTransaction(newBlock.transactions[i], referenceBlockchain, reorg)
+      }
+    }
 
     // Check if the sum of output transactions are equal the sum of input transactions + MINING_REWARD (representing the reward for the block miner)
     let sumOfInputsAmount = R.sum(R.flatten(R.map(R.compose(R.map(R.prop('amount')), R.prop('inputs'), R.prop('data')), newBlock.transactions))) + Config.MINING_REWARD
@@ -192,6 +245,7 @@ class Blockchain {
     // Check if the block is the Premine, Block #1, and expect a reward of PREMINE_REWARD (Minus the usual block reward).
     let premineTotalReward = Config.PREMINE_REWARD - Config.MINING_REWARD
     if (newBlock.index === 1) sumOfInputsAmount += premineTotalReward
+
     let sumOfOutputsAmount = R.sum(R.flatten(R.map(R.compose(R.map(R.prop('amount')), R.prop('outputs'), R.prop('data')), newBlock.transactions)))
 
     let isInputsAmountGreaterOrEqualThanOutputsAmount = R.gte(sumOfInputsAmount, sumOfOutputsAmount)
@@ -224,16 +278,24 @@ class Blockchain {
     return true
   }
 
-  checkTransaction (transaction, referenceBlockchain = this.blocks) {
+  checkTransaction (transaction, referenceBlockchain = this.blocks, reorg = false) {
     // Check the transaction
     transaction.check(transaction)
 
     // Verify spent inputs are less (or equal) in quantity to MAX_UTXOS
     // CONSENSUS: This takes affect past block 4,000. Previous transactions may waive this check.
     if (transaction.data.inputs > Config.MAX_UTXOS && referenceBlockchain.length > 4000) {
-      console.error(`Transaction '${transaction.id}' exceeds the maximum input threshhold (Attempted: ${transaction.data.inputs}, Max: ${Config.MAX_UTXOS})`)
-      throw new TransactionAssertionError(`Transaction '${transaction.id}' exceeds the maximum input threshhold (Attempted: ${transaction.data.inputs}, Max: ${Config.MAX_UTXOS})`, transaction)
+      console.error(`Transaction '${transaction.id}' exceeds the maximum input threshold (Attempted: ${transaction.data.inputs}, Max: ${Config.MAX_UTXOS})`)
+      throw new TransactionAssertionError(`Transaction '${transaction.id}' exceeds the maximum input threshold (Attempted: ${transaction.data.inputs}, Max: ${Config.MAX_UTXOS})`, transaction)
     }
+
+    // REORG ONLY
+    // During a reorg, only basic TX validity tests are ran, unspent tests will be ignored
+    // as a simple fix to reorgs causing "transaction already exists" errors. This fix will
+    // be made more advanced in the future to avoid consensus vulnerabilities.
+    console.info("reorg: " + reorg)
+    if (reorg)
+      return true
 
     // Verify if the transaction isn't already in the blockchain
     let isNotInBlockchain = R.all((block) => {

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -6,12 +6,23 @@ const R = require('ramda')
 
 class Node {
   constructor (host, port, peers, blockchain) {
+    this.syncing = false
     this.host = host
     this.port = port
     this.peers = []
     this.blockchain = blockchain
     this.hookBlockchain()
     this.connectToPeers(peers)
+  }
+
+  /* LOCAL STATUSES (To prevent accidental overloads, spam or bandwidth maxing) */
+
+  isSyncing () {
+    return this.syncing
+  }
+
+  setSyncing (status) {
+    this.syncing = status
   }
 
   hookBlockchain () {
@@ -97,6 +108,8 @@ class Node {
   }
 
   getBlocks (peer) {
+    if (this.isSyncing()) return
+    this.setSyncing(true)
     const URL = `${peer.url}/blockchain/blocks`
     let self = this
     console.info(`Getting blocks from: ${URL}`)
@@ -105,9 +118,11 @@ class Node {
       .then((res) => {
         // Check for what to do with the block list
         self.checkReceivedBlocks(Blocks.fromJson(res.body))
+        this.setSyncing(false)
       })
       .catch((err) => {
         console.warn(`Unable to get blocks from ${URL}: ${err.message}`)
+        this.setSyncing(false)
       })
   }
 
@@ -207,12 +222,21 @@ class Node {
       this.broadcast(this.getBlocks)
       return null
     } else if (heightDiff >= 2 && latestBlockHeld.index !== 0) { // Only add blocks that are newer than our last block
-      const newBlocks = R.takeLast(heightDiff, receivedBlocks);
-      console.info('Appending ' + heightDiff + ' received blocks to our chain')
-      this.blockchain.addBlocks(newBlocks)
-      return true
-    } else { // Received blockchain is longer than current blockchain
-      console.info('Received blockchain is longer than current blockchain')
+      console.info('Scanning for fork(s) on received chain...')
+      let forkTip = this.blockchain.checkForForkTip(receivedBlocks)
+      if (forkTip !== null) {
+        // Time for a re-org! After some validation checks
+        console.info('Valid fork found, preparing local blockchain reorganization...')
+        this.blockchain.replaceChain(receivedBlocks, forkTip)
+        return true
+      } else {
+        const newBlocks = R.takeLast(heightDiff, receivedBlocks)
+        console.info('No fork found, appending ' + heightDiff + ' received blocks to our chain')
+        this.blockchain.addBlocks(newBlocks)
+        return true
+      }
+    } else { // This can only be executed if our only block is the Genesis block (e.g: We have a clean installation)
+      console.info('Bootstrapped blockchain from peer, importing blockchain...')
       this.blockchain.replaceChain(receivedBlocks)
       return true
     }


### PR DESCRIPTION
Blockchain reorganizations added to combat accidental network splits & forks due to orphan blocks, these blocks will now be abandoned in favor of a longer (Thus, the "correct") blockchain.

Blocks are now written to disk once every 1000 blocks, instead of once per-block, greatly improving disk efficiency and general blockchain-related processing.

Network usage has also improved, a node will no longer requests the full blockchain from multiple peers simultaniously, only one peer can send a full blockchain, otherwise, this adds up to possibly hundreds of MBs of duplicate chain data.